### PR TITLE
Remove dismiss calls

### DIFF
--- a/Sources/WatchDatePicker/DatePickerView.swift
+++ b/Sources/WatchDatePicker/DatePickerView.swift
@@ -26,7 +26,6 @@ public struct DatePickerView: View {
   @State private var day = 0
   
   @Environment(\.locale) private var locale
-  @Environment(\.dismiss) private var dismiss
   
   private var newSelection: Date {
     locale.calendar.date(from: DateComponents(
@@ -121,7 +120,6 @@ public struct DatePickerView: View {
   }
   
   private func confirm(_ date: Date) {
-    if mode == .date { dismiss() }
     onCompletion?(date)
     selection = date
   }

--- a/Sources/WatchDatePicker/TimePickerView.swift
+++ b/Sources/WatchDatePicker/TimePickerView.swift
@@ -28,7 +28,6 @@ public struct TimePickerView: View {
   var onCompletion: ((Date) -> Void)?
 
   @Environment(\.locale) private var locale
-  @Environment(\.dismiss) private var dismiss
   private enum HourPeriod: Int { case am = 0, pm = 12; var offset: Int { rawValue } }
   private enum Component { case hour, minute }
   @State private var hourPeriod = HourPeriod.am
@@ -135,7 +134,6 @@ public struct TimePickerView: View {
   }
   
   private func _onCompletion() {
-    if mode == .time { dismiss() }
     onCompletion?(newSelection)
   }
   


### PR DESCRIPTION
Hello! I'm opening this for a discussion. I've been using this package in an app and the date picker is within a sheet. On iOS dismiss() appears to only back up one scene, while on watchOS it backs up to the root. Because of this, when using the library in a sheet it will dismiss the sheet as well, losing any edits. Everything works correctly without this dismiss call, so I'm not even sure if it's needed (therein lies the discussion). I'm wondering more broadly if this is something you've encountered and how you might have overcome it?

Thanks for such an awesome library, this really save me an immeasurable amount of time today trying to port my app!