### PR TITLE
Fixes compiling for watchOS only and Digital Crown bug

### DIFF
--- a/Examples/DatePickerExamplesApp.swift
+++ b/Examples/DatePickerExamplesApp.swift
@@ -104,6 +104,7 @@ struct VariousExample: View {
         }
         
         DatePicker("Time (Pink)", selection: $value, displayedComponents: [.hourAndMinute])
+          .environment(\.timeInputViewMonospacedDigit, true)
           .tint(.pink)
         
         DatePicker("Date & Time", selection: $value)

--- a/Examples/WatchDatePickerExamples.xcodeproj/project.pbxproj
+++ b/Examples/WatchDatePickerExamples.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3B029E03285FADA0000346CD /* WatchDatePicker in Frameworks */ = {isa = PBXBuildFile; productRef = 3B029E02285FADA0000346CD /* WatchDatePicker */; };
 		3B029E07285FC070000346CD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B029E04285FBFF9000346CD /* Assets.xcassets */; };
 		3BF815CB288E375400693A16 /* DatePickerScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF815CA288E375400693A16 /* DatePickerScreenshots.swift */; };
+		F0534F91292F0F9400D0487A /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0534F90292F0F8700D0487A /* SwiftUI.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		3BA47621285FAD6800431D20 /* watch-date-picker */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "watch-date-picker"; path = ..; sourceTree = "<group>"; };
 		3BF815C6288E375300693A16 /* Examples WatchKit Screenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Examples WatchKit Screenshots.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BF815CA288E375400693A16 /* DatePickerScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerScreenshots.swift; sourceTree = "<group>"; };
+		F0534F90292F0F8700D0487A /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS9.1.sdk/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +93,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0534F91292F0F9400D0487A /* SwiftUI.framework in Frameworks */,
 				3B029E03285FADA0000346CD /* WatchDatePicker in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -132,6 +135,7 @@
 		3B029E01285FADA0000346CD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F0534F90292F0F8700D0487A /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,6 @@ let package = Package(
   defaultLocalization: "en",
   platforms: [
     .watchOS(.v8),
-    // .macOS(.v12),
-    // .iOS(.v15),
-    // .tvOS(.v15),
   ],
   products: [
     .library(name: "WatchDatePicker", targets: ["WatchDatePicker"]),

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+Circular.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+Circular.swift
@@ -1,6 +1,8 @@
 #if os(watchOS)
 import SwiftUI
 
+private let SUGGESTED_SIZE: CGFloat = 32.0
+
 @available(macOS, unavailable)
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
@@ -12,16 +14,25 @@ extension ButtonStyle where Self == CircularButtonStyle {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 struct CircularButtonStyle: ButtonStyle {
+  @State private var padding: CGFloat = 0.0
   var color: Color
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .font(.system(size: .circularButtonFontSize, weight: .bold, design: .rounded))
-      .frame(width: .circularButtonDiameter, height: .circularButtonDiameter)
+      .font(.title3.bold())
+      .padding(padding)
+      //.frame(width: .circularButtonDiameter, height: .circularButtonDiameter)
       .foregroundColor(color == .gray ? .primary : color)
       .background { Circle().fill(color.opacity(color == .gray ? 0.38 : 0.3)) }
       .scaleEffect(configuration.isPressed ? 0.9 : 1)
       .opacity(configuration.isPressed ? 0.5 : 1)
+      .readSize { size in
+        guard padding == 0.0 else {
+          return
+        }
+        
+        padding = ceil((SUGGESTED_SIZE - min(size.width, SUGGESTED_SIZE)) * 0.5)
+      }
   }
 }
 #endif

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+Circular.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+Circular.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 @available(macOS, unavailable)
@@ -23,3 +24,4 @@ struct CircularButtonStyle: ButtonStyle {
       .opacity(configuration.isPressed ? 0.5 : 1)
   }
 }
+#endif

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 @available(macOS, unavailable)
@@ -59,3 +60,4 @@ struct TimePeriodButtonStyle: ButtonStyle {
       }
   }
 }
+#endif

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
@@ -1,6 +1,8 @@
 #if os(watchOS)
 import SwiftUI
 
+private let SUGGESTED_HEIGHT: CGFloat = 51.0
+
 @available(macOS, unavailable)
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
@@ -14,18 +16,46 @@ extension ButtonStyle where Self == TimeComponentButtonStyle {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 struct TimeComponentButtonStyle: ButtonStyle {
+  @State private var padding: CGFloat = 0.0
+  
   var isFocused: Bool
 
   @Environment(\.timeInputViewFocusTint) private var focusTint
+  @Environment(\.timeInputViewMonospacedDigit) private var useMonospacedFont
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .frame(width: .timeComponentButtonWidth, height: .timeComponentButtonHeight)
+      .frame(width: usableWidth)
+      .padding(.vertical, padding)
       .offset(y: 0.5)
+      .readSize(onChange: { size in
+        guard padding == 0.0 else {
+          return
+        }
+        
+        padding = ceil((SUGGESTED_HEIGHT - size.height) * 0.5)
+      })
       .overlay {
-        RoundedRectangle(cornerRadius: .timeComponentButtonCornerRadius)
+        RoundedRectangle(cornerRadius: 8)
           .strokeBorder(isFocused ? focusTint ?? .green : .timeComponentButtonBorder, lineWidth: 1.5)
       }
+  }
+  
+  private var usableWidth: CGFloat {
+    get {
+      (fontPointSize() * 2.0) - 16.0
+    }
+  }
+  
+  private func fontPointSize() -> CGFloat {
+    let baseFont = UIFont.preferredFont(forTextStyle: .title2)
+    
+    guard useMonospacedFont ?? true else {
+      return baseFont.pointSize
+    }
+    
+    let monospacedDigitFont = UIFont.monospacedDigitSystemFont(ofSize: baseFont.pointSize, weight: isFocused ? .semibold : .regular)
+    return CGFloat(monospacedDigitFont.pointSize)
   }
 }
 

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
@@ -1,7 +1,7 @@
 #if os(watchOS)
 import SwiftUI
 
-private let SUGGESTED_HEIGHT: CGFloat = 51.0
+private let SUGGESTED_HEIGHT: CGFloat = 48.0
 
 @available(macOS, unavailable)
 @available(iOS, unavailable)

--- a/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
+++ b/Sources/WatchDatePicker/Additions/ButtonStyle+TimeInputView.swift
@@ -49,12 +49,12 @@ struct TimePeriodButtonStyle: ButtonStyle {
   func makeBody(configuration: Configuration) -> some View {
     let tint = highlightTint.map { AnyShapeStyle($0) } ?? AnyShapeStyle(.tint)
     return configuration.label
-      .frame(minWidth: .timePeriodButtonMinWidth, maxHeight: .timePeriodButtonMaxHeight)
-      .font(.system(size: .timePeriodButtonFontSize, weight: isHighlighted ? .semibold : .regular))
+      .padding(.horizontal, 4)
+      .font(isHighlighted ? .body.bold() : .body)
       .opacity(configuration.isPressed ? 0.5 : isHighlighted ? 1 : 0.8)
       .foregroundStyle(isHighlighted ? AnyShapeStyle(.black) : tint)
       .background {
-        RoundedRectangle(cornerRadius: .timePeriodButtonCornerRadius)
+        RoundedRectangle(cornerRadius: 4)
           .fill(isHighlighted ? tint : AnyShapeStyle(.clear))
           .offset(y: 0.5)
       }

--- a/Sources/WatchDatePicker/Additions/EnvironmentValues+DateInputView.swift
+++ b/Sources/WatchDatePicker/Additions/EnvironmentValues+DateInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 @available(watchOS 8, *)
@@ -38,3 +39,4 @@ public extension EnvironmentValues {
 
 struct DateInputViewShowsMonthBeforeDayKey: EnvironmentKey { static let defaultValue: Bool? = nil }
 struct DateInputViewTextCaseKey: EnvironmentKey { static let defaultValue: Text.Case? = .uppercase }
+#endif

--- a/Sources/WatchDatePicker/Additions/EnvironmentValues+DatePicker.swift
+++ b/Sources/WatchDatePicker/Additions/EnvironmentValues+DatePicker.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 @available(watchOS 8, *)
@@ -77,3 +78,4 @@ struct DatePickerInteractionStyleKey: EnvironmentKey { static let defaultValue =
 // struct DatePickerUsesBottomButtonsKey: EnvironmentKey { static let defaultValue: Bool? = nil }
 struct DatePickerConfirmationTitleKeyKey: EnvironmentKey { static let defaultValue: LocalizedStringKey? = nil }
 struct DatePickerConfirmationTintKey: EnvironmentKey { static let defaultValue: Color? = nil }
+#endif

--- a/Sources/WatchDatePicker/Additions/EnvironmentValues+TimeInputView.swift
+++ b/Sources/WatchDatePicker/Additions/EnvironmentValues+TimeInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 // TODO: add full mark customization for watchOS 9 using AnyShape
@@ -147,3 +148,4 @@ struct TimeInputViewSelectionTintKey: EnvironmentKey { static let defaultValue: 
 //struct TimeInputViewHeavyMarkKey: EnvironmentKey { static let defaultValue: AnyShape? = nil }
 //@available(watchOS 9, *)
 //struct TimeInputViewSelectionIndicatorKey: EnvironmentKey { static let defaultValue: AnyShape? = nil }
+#endif

--- a/Sources/WatchDatePicker/Additions/Locale+DateInputView.swift
+++ b/Sources/WatchDatePicker/Additions/Locale+DateInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import Foundation
 
 extension Locale {
@@ -28,3 +29,4 @@ extension Locale {
   //    return …
   //  }
 }
+#endif

--- a/Sources/WatchDatePicker/Additions/Locale+WatchDatePicker.swift
+++ b/Sources/WatchDatePicker/Additions/Locale+WatchDatePicker.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import Foundation
 
 extension Locale {
@@ -20,3 +21,4 @@ extension Locale {
     "zh-Hant",
   ]
 }
+#endif

--- a/Sources/WatchDatePicker/Additions/View+Size.swift
+++ b/Sources/WatchDatePicker/Additions/View+Size.swift
@@ -1,0 +1,27 @@
+//
+//  View+Size.swift
+//  
+//
+//  Created by Nikhil Nigade on 23/11/22.
+//
+
+#if os(watchOS)
+import SwiftUI
+
+extension View {
+  func readSize(onChange: @escaping (CGSize) -> Void) -> some View {
+    background(
+      GeometryReader { geometryProxy in
+        Color.clear
+          .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
+      }
+    )
+    .onPreferenceChange(SizePreferenceKey.self, perform: onChange)
+  }
+}
+
+private struct SizePreferenceKey: PreferenceKey {
+  static var defaultValue: CGSize = .zero
+  static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
+}
+#endif

--- a/Sources/WatchDatePicker/Additions/View+WatchStatusBarHidden.swift
+++ b/Sources/WatchDatePicker/Additions/View+WatchStatusBarHidden.swift
@@ -7,10 +7,15 @@ import SwiftUI
 @available(tvOS, unavailable)
 extension View {
   func watchStatusBar(hidden: Bool) -> some View {
-    toolbar {
-      ToolbarItem(placement: .confirmationAction) {
-        Button("", action: {})
-          .accessibilityHidden(true)
+    if #available(watchOS 9, *) {
+      return self.toolbar(hidden ? .hidden : .visible, for: .automatic)
+    }
+    else {
+      return self.toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button("", action: {})
+            .accessibilityHidden(true)
+        }
       }
     }
   }

--- a/Sources/WatchDatePicker/Additions/View+WatchStatusBarHidden.swift
+++ b/Sources/WatchDatePicker/Additions/View+WatchStatusBarHidden.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 @available(watchOS 8, *)
@@ -14,3 +15,4 @@ extension View {
     }
   }
 }
+#endif

--- a/Sources/WatchDatePicker/Constants.swift
+++ b/Sources/WatchDatePicker/Constants.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 import WatchKit
 
@@ -193,3 +194,4 @@ extension CGSize {
 extension Color {
   static let timeComponentButtonBorder = Color(white: 0.298)
 }
+#endif

--- a/Sources/WatchDatePicker/Constants.swift
+++ b/Sources/WatchDatePicker/Constants.swift
@@ -35,36 +35,6 @@ enum WatchDeviceSize: Double {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 extension CGFloat {
-  static var clockFacePadding: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return -13
-    case ._41mm: return -21
-    case ._44mm: return -13
-    case ._45mm: return -23
-    case ._49mm: return -29.5
-    }
-  }
-  
-  static var hourAndMinuteCircularButtonsBottomPadding: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return -22
-    case ._41mm: return -27.5
-    case ._45mm: return -28.5
-    case ._49mm: return -31.5
-    default: return -26
-    }
-  }
-  
-  static var hourAndMinuteCircularButtonsHorizontalPadding: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 30
-    case ._41mm: return 30
-    case ._45mm: return 34
-    case ._49mm: return 34
-    default: return 32
-    }
-  }
-
   static var componentFontSize: Self {
     switch WatchDeviceSize.current {
     case ._40mm: return 28

--- a/Sources/WatchDatePicker/Constants.swift
+++ b/Sources/WatchDatePicker/Constants.swift
@@ -48,32 +48,6 @@ extension CGFloat {
     default: return 1
     }
   }
-  
-  static var timeComponentButtonWidth: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 39
-    // case ._41mm: return 40
-    case ._45mm, ._49mm: return 51
-    default: return 46
-    }
-  }
-
-  static var timeComponentButtonHeight: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 39
-    case ._41mm: return 52
-    case ._44mm: return 51
-    case ._45mm: return 58
-    case ._49mm: return 56
-    }
-  }
-
-  static var timeComponentButtonCornerRadius: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 7
-    default: return 11
-    }
-  }
 }
 
 @available(macOS, unavailable)

--- a/Sources/WatchDatePicker/Constants.swift
+++ b/Sources/WatchDatePicker/Constants.swift
@@ -35,16 +35,6 @@ enum WatchDeviceSize: Double {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 extension CGFloat {
-  static var componentFontSize: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 28
-    case ._41mm: return 34.5
-    case ._44mm: return 32
-    case ._45mm: return 39
-    case ._49mm: return 38
-    }
-  }
-  
   static var selectionIndicatorRadius: Self {
     switch WatchDeviceSize.current {
     case ._45mm, ._49mm: return 2.75
@@ -56,59 +46,6 @@ extension CGFloat {
     switch WatchDeviceSize.current {
     case ._41mm, ._45mm, ._49mm: return 0.8
     default: return 1
-    }
-  }
-  
-  static var circularButtonDiameter: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 33.5
-    // case ._41mm: return 35
-    case ._45mm: return 41.5
-    case ._49mm: return 40.5
-    default: return 37.5
-    }
-  }
-  
-  static var circularButtonFontSize: Self {
-    switch WatchDeviceSize.current {
-    case ._40mm: return 17.5
-    // case ._41mm: return 35
-    case ._45mm: return 22.5
-    case ._49mm: return 21.5
-    default: return 20.5
-    }
-  }
-  
-  // TODO: consider using padding for this instead
-  static var timePeriodButtonMinWidth: Self {
-    switch WatchDeviceSize.current {
-    case ._41mm: return 29.5
-    case ._45mm, ._49mm: return 32.5
-    default: return 24.5
-    }
-  }
-  
-  static var timePeriodButtonMaxHeight: Self {
-    switch WatchDeviceSize.current {
-    case ._41mm: return 19
-    case ._45mm, ._49mm: return 21
-    default: return 16
-    }
-  }
-  
-  static var timePeriodButtonFontSize: Self {
-    switch WatchDeviceSize.current {
-    case ._41mm: return 17
-    case ._45mm, ._49mm: return 19
-    default: return 15
-    }
-  }
-  
-  static var timePeriodButtonCornerRadius: Self {
-    switch WatchDeviceSize.current {
-    case ._41mm: return 4
-    case ._45mm, ._49mm: return 5
-    default: return 3
     }
   }
   

--- a/Sources/WatchDatePicker/DateInputView.swift
+++ b/Sources/WatchDatePicker/DateInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 /// A control for the inputting of date values.
@@ -208,3 +209,4 @@ struct DateInputView_Previews: PreviewProvider {
       .previewDisplayName("Danish")
   }
 }
+#endif

--- a/Sources/WatchDatePicker/DatePicker.swift
+++ b/Sources/WatchDatePicker/DatePicker.swift
@@ -176,81 +176,84 @@ public struct DatePicker<Label: View>: View {
   }
   
   @ViewBuilder private var mainBody: some View {
-    switch displayedComponents {
-    case [.date, .hourAndMinute]:
-      NavigationView {
-        VStack {
-          DateInputView(selection: $newSelection, minimumDate: minimumDate, maximumDate: maximumDate)
-            // ._statusBar(hidden: true)
-            .watchStatusBar(hidden: true)
-            .overlay {
-              NavigationLink(isActive: $secondViewIsPresented) {
-                TimeInputView(selection: $newSelection)
-                  .edgesIgnoringSafeArea(.bottom)
-                  .padding(-10)
-                  .navigationTitle(formattedNavigationTitle)
-                  .navigationBarTitleDisplayMode(.inline)
-                  .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                      Button(action: submit) {
-                        Text("Done", bundle: .module)
+    GeometryReader { rootProxy in
+      switch displayedComponents {
+      case [.date, .hourAndMinute]:
+        NavigationView {
+          VStack {
+            DateInputView(selection: $newSelection, minimumDate: minimumDate, maximumDate: maximumDate)
+              // ._statusBar(hidden: true)
+              .watchStatusBar(hidden: true)
+              .overlay {
+                NavigationLink(isActive: $secondViewIsPresented) {
+                  TimeInputView(selection: $newSelection)
+                    .edgesIgnoringSafeArea(.bottom)
+                    .padding(-10)
+                    .navigationTitle(formattedNavigationTitle)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                      ToolbarItem(placement: .confirmationAction) {
+                        Button(action: submit) {
+                          Text("Done", bundle: .module)
+                        }
                       }
                     }
-                  }
-              } label: {
-                EmptyView()
+                } label: {
+                  EmptyView()
+                }
+                .hidden()
               }
-              .hidden()
-            }
+            
+            confirmationButton
+          }
+          .edgesIgnoringSafeArea(.bottom)
+          .scenePadding(.bottom)
+        }
+        
+      case .date:
+        VStack(spacing: 10) {
+          DateInputView(selection: $newSelection, minimumDate: minimumDate, maximumDate: maximumDate)
+            .frame(height: max(120, WKInterfaceDevice.current().screenBounds.height * 0.55))
+          // .padding(.top, 20)
+          // .onAppear { print(WKInterfaceDevice.current().screenBounds.height * 0.6) }
           
-          confirmationButton
+          circularButtons
+            .padding(.bottom, -21)
         }
-        .edgesIgnoringSafeArea(.bottom)
-        .scenePadding(.bottom)
-      }
-      
-    case .date:
-      VStack(spacing: 10) {
-        DateInputView(selection: $newSelection, minimumDate: minimumDate, maximumDate: maximumDate)
-          .frame(height: max(120, WKInterfaceDevice.current().screenBounds.height * 0.55))
-        // .padding(.top, 20)
-        // .onAppear { print(WKInterfaceDevice.current().screenBounds.height * 0.6) }
+        .frame(maxHeight: .infinity)
+        .edgesIgnoringSafeArea(.all)
+        .navigationBarHidden(true)
+        // ._statusBar(hidden: true)
+        .watchStatusBar(hidden: true)
         
-        circularButtons
-          .padding(.bottom, -21)
-      }
-      .frame(maxHeight: .infinity)
-      .edgesIgnoringSafeArea(.all)
-      .navigationBarHidden(true)
-      // ._statusBar(hidden: true)
-      .watchStatusBar(hidden: true)
-      
-    case .hourAndMinute:
-      ZStack(alignment: .bottom) {
-        TimeInputView(selection: $newSelection)
-          .offset(y: 10)
-        
-        circularButtons
-          .padding(.bottom, .hourAndMinuteCircularButtonsBottomPadding)
-          .padding(.horizontal, .hourAndMinuteCircularButtonsHorizontalPadding)
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .navigationBarHidden(true)
-      // ._statusBar(hidden: true)
-      .watchStatusBar(hidden: true)
-      .toolbar {
-        ToolbarItem(placement: .confirmationAction) {
-          Button("", action: {})
-            .accessibilityHidden(true)
+      case .hourAndMinute:
+        ZStack(alignment: .bottom) {
+          TimeInputView(selection: $newSelection)
+            .offset(y: rootProxy.safeAreaInsets.bottom * -0.5)
+          
+          circularButtons
+            .padding(.bottom, rootProxy.safeAreaInsets.bottom * 0.5)
+//            .padding(.bottom, .hourAndMinuteCircularButtonsBottomPadding)
+//            .padding(.horizontal, .hourAndMinuteCircularButtonsHorizontalPadding)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationBarHidden(true)
+        // ._statusBar(hidden: true)
+        .watchStatusBar(hidden: true)
+        .toolbar {
+          ToolbarItem(placement: .confirmationAction) {
+            Button("", action: {})
+              .accessibilityHidden(true)
+          }
+        }
+        .edgesIgnoringSafeArea(.all)
+  //      .padding(.bottom, -40)
+  //      .padding(.horizontal, -32)
+//        .offset(y: -(rootProxy.safeAreaInsets.top + rootProxy.safeAreaInsets.bottom) + 4)
+        
+      default:
+        fatalError()
       }
-      .edgesIgnoringSafeArea(.all)
-      .padding(.bottom, -40)
-      .padding(.horizontal, -32)
-      .offset(y: -45)
-      
-    default:
-      fatalError()
     }
   }
 

--- a/Sources/WatchDatePicker/DatePicker.swift
+++ b/Sources/WatchDatePicker/DatePicker.swift
@@ -182,13 +182,13 @@ public struct DatePicker<Label: View>: View {
         NavigationView {
           VStack {
             DateInputView(selection: $newSelection, minimumDate: minimumDate, maximumDate: maximumDate)
-              // ._statusBar(hidden: true)
               .watchStatusBar(hidden: true)
               .overlay {
                 NavigationLink(isActive: $secondViewIsPresented) {
                   TimeInputView(selection: $newSelection)
-                    .edgesIgnoringSafeArea(.bottom)
-                    .padding(-10)
+                    .padding(-5)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .edgesIgnoringSafeArea(.all)
                     .navigationTitle(formattedNavigationTitle)
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
@@ -233,12 +233,9 @@ public struct DatePicker<Label: View>: View {
           
           circularButtons
             .padding(.bottom, rootProxy.safeAreaInsets.bottom * 0.5)
-//            .padding(.bottom, .hourAndMinuteCircularButtonsBottomPadding)
-//            .padding(.horizontal, .hourAndMinuteCircularButtonsHorizontalPadding)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationBarHidden(true)
-        // ._statusBar(hidden: true)
         .watchStatusBar(hidden: true)
         .toolbar {
           ToolbarItem(placement: .confirmationAction) {
@@ -247,9 +244,6 @@ public struct DatePicker<Label: View>: View {
           }
         }
         .edgesIgnoringSafeArea(.all)
-  //      .padding(.bottom, -40)
-  //      .padding(.horizontal, -32)
-//        .offset(y: -(rootProxy.safeAreaInsets.top + rootProxy.safeAreaInsets.bottom) + 4)
         
       default:
         fatalError()

--- a/Sources/WatchDatePicker/DatePicker.swift
+++ b/Sources/WatchDatePicker/DatePicker.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 // TODO: accessibility
@@ -639,3 +640,4 @@ struct DatePicker_Previews: PreviewProvider {
 //    .previewDisplayName("Mode: Date & Time (Step 2)")
   }
 }
+#endif

--- a/Sources/WatchDatePicker/TimeInputView.swift
+++ b/Sources/WatchDatePicker/TimeInputView.swift
@@ -55,8 +55,20 @@ public struct TimeInputView: View {
   @State private var focusedComponent = Component.hour
   @State private var hour = 0
   @State private var minute = 0
-  private var hourBinding: Binding<Double> { Binding { Double(hour) } set: { hour = Int($0) } }
-  private var minuteBinding: Binding<Double> { Binding { Double(minute) } set: { minute = Int($0) } }
+  private var hourBinding: Binding<Double> {
+    Binding { Double(hour) }
+    set: {
+      hour = Int($0)
+    }
+  }
+  
+  private var minuteBinding: Binding<Double> {
+    Binding { Double(minute) }
+    set: {
+      minute = Int($0)
+    }
+  }
+  
   private var hourMultiple: Int { twentyFourHour == true ? 24 : 12 }
   private var minuteMultiple: Int { 60 }
   private var normalizedHour: Int { (hour < 0 ? hourMultiple - (abs(hour) % hourMultiple) : hour) % hourMultiple }
@@ -244,10 +256,10 @@ public struct TimeInputView: View {
           .focusable()
           .digitalCrownRotation(
             hourBinding,
-            from: -Double.infinity,
-            through: Double.infinity,
-            by: nil,
-            sensitivity: .low,
+            from: 0,
+            through: 24,
+            by: 1,
+            sensitivity: .medium,
             isContinuous: true,
             isHapticFeedbackEnabled: true
           )
@@ -261,9 +273,9 @@ public struct TimeInputView: View {
           .focusable()
           .digitalCrownRotation(
             minuteBinding,
-            from: -Double.infinity,
-            through: Double.infinity,
-            by: nil,
+            from: 0,
+            through: 60,
+            by: 1,
             sensitivity: .medium,
             isContinuous: true,
             isHapticFeedbackEnabled: true

--- a/Sources/WatchDatePicker/TimeInputView.swift
+++ b/Sources/WatchDatePicker/TimeInputView.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import SwiftUI
 
 // TODO: cache the clock face to an image for better performance?
@@ -324,3 +325,4 @@ struct TimeInputView_Previews: PreviewProvider {
 //      .previewDevice("Apple Watch Series 6 - 40mm")
   }
 }
+#endif


### PR DESCRIPTION
<ol>
<li>
<p>Adds conditional compile time checks for <b>watchOS</b> only.</p>

<p>When compiling mixed projects, the Package gets picked up by `xcodebuild`, for example: for iOS, and the compiler then throws errors about not being able to find `WatchKit`. </p>

<p>This is the unfortunate state of SPM packages at the moment using the latest toolchains, and this PR works around that.</p>
</li>

<li><p>Fixes a bug occurring on watchOS 9.1 when building with Xcode 14.1 RC 2 where the time input would crash on appear due to invalid values setup on the Digital Crown event modifier. </p></li>
</ol>